### PR TITLE
ci: use github app token

### DIFF
--- a/.github/workflows/bumpversion.yml
+++ b/.github/workflows/bumpversion.yml
@@ -11,15 +11,19 @@ jobs:
     runs-on: ubuntu-latest
     name: "Bump version and create changelog with commitizen"
     steps:
+      - uses: actions/create-github-app-token@v1
+        id: app-token
+        with:
+          app-id: ${{ vars.ELEMENTSINTERACTIVE_BOT_APP_ID }}
+          private-key: ${{ secrets.ELEMENTSINTERACTIVE_BOT_PRIVATE_KEY }}
       - name: Check out
         uses: actions/checkout@v4
         with:
           fetch-depth: 0
-          token: "${{ secrets.GITHUB_TOKEN }}"
       - id: cz
         name: Create bump and changelog
         uses: commitizen-tools/commitizen-action@master
         with:
-          github_token: ${{ secrets.GITHUB_TOKEN }}
+          github_token: ${{ steps.app-token.outputs.token }}
       - name: Print Version
         run: echo "Bumped to version ${{ steps.cz.outputs.version }}"


### PR DESCRIPTION
Our bump workflow was unable to trigger the dependent publish workflow due to using the GITLAB_TOKEN which has limitations to avoid recursive workflows. See https://docs.github.com/en/actions/writing-workflows/choosing-when-your-workflow-runs/triggering-a-workflow#triggering-a-workflow-from-a-workflow
So the solution is either to use a Personal Access Token, or a GitHub App Installation Token.
The GitHub App Installation Token seems like a more future-proof setup, so here is an initial attempt at getting it to work.

The idea here is that we now have an organization app which should be given access to this repository: https://github.com/apps/elements-helper

Then we use a github action [actions/create-github-app-token@v1](https://github.com/actions/create-github-app-token) to create a special 1-hour token from the app, which our actions can use! And with this, the publish workflow should be created 😄

I've created the associated ELEMENTS_HELPER_APP_ID and ELEMENTS_HELPER_PRIVATE_KEY which will be used by the action to create the token.