### PR TITLE
ci: fix github app token use in bump action

### DIFF
--- a/.github/workflows/bumpversion.yml
+++ b/.github/workflows/bumpversion.yml
@@ -16,10 +16,13 @@ jobs:
         with:
           app-id: ${{ vars.ELEMENTSINTERACTIVE_BOT_APP_ID }}
           private-key: ${{ secrets.ELEMENTSINTERACTIVE_BOT_PRIVATE_KEY }}
-      - name: Check out
-        uses: actions/checkout@v4
+      - uses: actions/checkout@v4
         with:
           fetch-depth: 0
+          token: ${{ steps.app-token.outputs.token }}
+          ref: ${{ github.head_ref }}
+          # Make sure the value of GITHUB_TOKEN will not be persisted in repo's config
+          persist-credentials: false
       - id: cz
         name: Create bump and changelog
         uses: commitizen-tools/commitizen-action@master


### PR DESCRIPTION
We may also need to `checkout` using the github app token

From https://github.com/actions/create-github-app-token?tab=readme-ov-file#use-app-token-with-actionscheckout