### PR TITLE
feat(#17): rework cli interface

### DIFF
--- a/README.md
+++ b/README.md
@@ -107,10 +107,9 @@ Only the **Reporting** and **Scanning** sections of configuration parameters are
 In this case you may choose to create a config file such as the following:
 
 ```toml
-gitlab-groups = ["namespace/group", "namespace/group/cool-repo"]
-gitlab-projects = ["namespace/group/cool-repo"]
-report-slack-channel = "sheriff-report-test"
-report-gitlab-issue = true
+url = ["namespace/group", "namespace/group/cool-repo"]
+report-to-slack-channel = "sheriff-report-test"
+report-to-gitlab-issue = true
 ```
 
 And if you wish to specify a different file, you can do so with `sheriff patrol --config your-config-file.toml`.

--- a/internal/gitlab/client.go
+++ b/internal/gitlab/client.go
@@ -10,8 +10,8 @@ import (
 )
 
 type iclient interface {
-	ListGroups(opt *gitlab.ListGroupsOptions, options ...gitlab.RequestOptionFunc) ([]*gitlab.Group, *gitlab.Response, error)
-	ListGroupProjects(groupId int, opt *gitlab.ListGroupProjectsOptions, options ...gitlab.RequestOptionFunc) ([]*gitlab.Project, *gitlab.Response, error)
+	GetProject(pid interface{}, opt *gitlab.GetProjectOptions, options ...gitlab.RequestOptionFunc) (*gitlab.Project, *gitlab.Response, error)
+	ListGroupProjects(gid interface{}, opt *gitlab.ListGroupProjectsOptions, options ...gitlab.RequestOptionFunc) ([]*gitlab.Project, *gitlab.Response, error)
 	ListProjectIssues(projectId interface{}, opt *gitlab.ListProjectIssuesOptions, options ...gitlab.RequestOptionFunc) ([]*gitlab.Issue, *gitlab.Response, error)
 	CreateIssue(projectId interface{}, opt *gitlab.CreateIssueOptions, options ...gitlab.RequestOptionFunc) (*gitlab.Issue, *gitlab.Response, error)
 	UpdateIssue(projectId interface{}, issueId int, opt *gitlab.UpdateIssueOptions, options ...gitlab.RequestOptionFunc) (*gitlab.Issue, *gitlab.Response, error)
@@ -21,12 +21,12 @@ type client struct {
 	client *gitlab.Client
 }
 
-func (c *client) ListGroups(opt *gitlab.ListGroupsOptions, options ...gitlab.RequestOptionFunc) ([]*gitlab.Group, *gitlab.Response, error) {
-	return c.client.Groups.ListGroups(opt, options...)
+func (c *client) GetProject(gid interface{}, opt *gitlab.GetProjectOptions, options ...gitlab.RequestOptionFunc) (*gitlab.Project, *gitlab.Response, error) {
+	return c.client.Projects.GetProject(gid, opt, options...)
 }
 
-func (c *client) ListGroupProjects(groupId int, opt *gitlab.ListGroupProjectsOptions, options ...gitlab.RequestOptionFunc) ([]*gitlab.Project, *gitlab.Response, error) {
-	return c.client.Groups.ListGroupProjects(groupId, opt, options...)
+func (c *client) ListGroupProjects(gid interface{}, opt *gitlab.ListGroupProjectsOptions, options ...gitlab.RequestOptionFunc) ([]*gitlab.Project, *gitlab.Response, error) {
+	return c.client.Groups.ListGroupProjects(gid, opt, options...)
 }
 
 func (c *client) ListProjectIssues(projectId interface{}, opt *gitlab.ListProjectIssuesOptions, options ...gitlab.RequestOptionFunc) ([]*gitlab.Issue, *gitlab.Response, error) {

--- a/internal/patrol/config_test.go
+++ b/internal/patrol/config_test.go
@@ -14,7 +14,7 @@ func TestGetConfiguration(t *testing.T) {
 		wantErr    bool
 		wantConfig scanner.ProjectConfig
 	}{
-		{"testdata/valid.toml", true, false, scanner.ProjectConfig{SlackChannel: "the-devils-slack-channel"}},
+		{"testdata/valid.toml", true, false, scanner.ProjectConfig{ReportToSlackChannel: "the-devils-slack-channel"}},
 		{"testdata/invalid.toml", true, true, scanner.ProjectConfig{}},
 		{"testdata/nonexistent.toml", false, false, scanner.ProjectConfig{}},
 		{"testdata/valid_with_ack.toml", true, false, scanner.ProjectConfig{Acknowledged: []scanner.AcknowledgedVuln{{Code: "CSV111", Reason: "not relevant"}, {Code: "CSV222", Reason: ""}}}},

--- a/internal/patrol/patrol_test.go
+++ b/internal/patrol/patrol_test.go
@@ -18,7 +18,7 @@ func TestNewService(t *testing.T) {
 
 func TestScanNoProjects(t *testing.T) {
 	mockGitlabService := &mockGitlabService{}
-	mockGitlabService.On("GetProjectList", []string{"group/to/scan"}, []string{}).Return([]gitlab.Project{}, nil)
+	mockGitlabService.On("GetProjectList", []string{"group/to/scan"}).Return([]gitlab.Project{}, nil)
 
 	mockSlackService := &mockSlackService{}
 
@@ -30,7 +30,15 @@ func TestScanNoProjects(t *testing.T) {
 
 	svc := New(mockGitlabService, mockSlackService, mockGitService, mockOSVService)
 
-	warn, err := svc.Patrol([]string{"group/to/scan"}, []string{}, true, "channel", true, false, false)
+	warn, err := svc.Patrol(PatrolArgs{
+		Locations:             []ProjectLocation{{Type: Gitlab, Path: "group/to/scan"}},
+		ReportToEmails:        []string{},
+		ReportToSlackChannel:  "channel",
+		ReportToIssue:         true,
+		EnableProjectReportTo: true,
+		Verbose:               true,
+		SilentReport:          false,
+	})
 
 	assert.Nil(t, err)
 	assert.Nil(t, warn)
@@ -40,7 +48,7 @@ func TestScanNoProjects(t *testing.T) {
 
 func TestScanNonVulnerableProject(t *testing.T) {
 	mockGitlabService := &mockGitlabService{}
-	mockGitlabService.On("GetProjectList", []string{"group/to/scan"}, []string{}).Return([]gitlab.Project{{Name: "Hello World", HTTPURLToRepo: "https://gitlab.com/group/to/scan.git"}}, nil)
+	mockGitlabService.On("GetProjectList", []string{"group/to/scan"}).Return([]gitlab.Project{{Name: "Hello World", HTTPURLToRepo: "https://gitlab.com/group/to/scan.git"}}, nil)
 	mockGitlabService.On("CloseVulnerabilityIssue", mock.Anything).Return(nil)
 
 	mockSlackService := &mockSlackService{}
@@ -55,7 +63,15 @@ func TestScanNonVulnerableProject(t *testing.T) {
 
 	svc := New(mockGitlabService, mockSlackService, mockGitService, mockOSVService)
 
-	warn, err := svc.Patrol([]string{"group/to/scan"}, []string{}, true, "channel", true, false, false)
+	warn, err := svc.Patrol(PatrolArgs{
+		Locations:             []ProjectLocation{{Type: Gitlab, Path: "group/to/scan"}},
+		ReportToEmails:        []string{},
+		ReportToSlackChannel:  "channel",
+		ReportToIssue:         true,
+		EnableProjectReportTo: true,
+		Verbose:               true,
+		SilentReport:          false,
+	})
 
 	assert.Nil(t, err)
 	assert.Nil(t, warn)
@@ -65,7 +81,7 @@ func TestScanNonVulnerableProject(t *testing.T) {
 
 func TestScanVulnerableProject(t *testing.T) {
 	mockGitlabService := &mockGitlabService{}
-	mockGitlabService.On("GetProjectList", []string{"group/to/scan"}, []string{}).Return([]gitlab.Project{{Name: "Hello World", HTTPURLToRepo: "https://gitlab.com/group/to/scan.git"}}, nil)
+	mockGitlabService.On("GetProjectList", []string{"group/to/scan"}).Return([]gitlab.Project{{Name: "Hello World", HTTPURLToRepo: "https://gitlab.com/group/to/scan.git"}}, nil)
 	mockGitlabService.On("OpenVulnerabilityIssue", mock.Anything, mock.Anything).Return(&gitlab.Issue{}, nil)
 
 	mockSlackService := &mockSlackService{}
@@ -88,7 +104,15 @@ func TestScanVulnerableProject(t *testing.T) {
 
 	svc := New(mockGitlabService, mockSlackService, mockGitService, mockOSVService)
 
-	warn, err := svc.Patrol([]string{"group/to/scan"}, []string{}, true, "channel", true, false, false)
+	warn, err := svc.Patrol(PatrolArgs{
+		Locations:             []ProjectLocation{{Type: Gitlab, Path: "group/to/scan"}},
+		ReportToEmails:        []string{},
+		ReportToSlackChannel:  "channel",
+		ReportToIssue:         true,
+		EnableProjectReportTo: true,
+		Verbose:               true,
+		SilentReport:          false,
+	})
 
 	assert.Nil(t, err)
 	assert.Nil(t, warn)
@@ -134,8 +158,8 @@ type mockGitlabService struct {
 	mock.Mock
 }
 
-func (c *mockGitlabService) GetProjectList(groupPaths []string, projectPaths []string) ([]gitlab.Project, error) {
-	args := c.Called(groupPaths, projectPaths)
+func (c *mockGitlabService) GetProjectList(paths []string) ([]gitlab.Project, error) {
+	args := c.Called(paths)
 	return args.Get(0).([]gitlab.Project), args.Error(1)
 }
 

--- a/internal/patrol/testdata/valid.toml
+++ b/internal/patrol/testdata/valid.toml
@@ -1,1 +1,1 @@
-slack-channel = "the-devils-slack-channel"
+report-to-slack-channel = "the-devils-slack-channel"

--- a/internal/publish/to_gitlab_test.go
+++ b/internal/publish/to_gitlab_test.go
@@ -206,8 +206,8 @@ type mockGitlabService struct {
 	mock.Mock
 }
 
-func (c *mockGitlabService) GetProjectList(groupPaths []string, projectPaths []string) ([]gitlab.Project, error) {
-	args := c.Called(groupPaths, projectPaths)
+func (c *mockGitlabService) GetProjectList(paths []string) ([]gitlab.Project, error) {
+	args := c.Called(paths)
 	return args.Get(0).([]gitlab.Project), args.Error(1)
 }
 

--- a/internal/publish/to_slack_test.go
+++ b/internal/publish/to_slack_test.go
@@ -24,7 +24,7 @@ func TestPublishAsGeneralSlackMessage(t *testing.T) {
 		},
 	}
 
-	err := PublishAsGeneralSlackMessage("channel", report, []string{"path/to/group"}, []string{"path/to/project"}, mockSlackService)
+	err := PublishAsGeneralSlackMessage("channel", report, []string{"path/to/group", "path/to/project"}, mockSlackService)
 
 	assert.Nil(t, err)
 	mockSlackService.AssertExpectations(t)
@@ -40,7 +40,7 @@ func TestPublishAsSpecificChannelSlackMessage(t *testing.T) {
 				Id: "CVE-2021-1234",
 			},
 		},
-		ProjectConfig: scanner.ProjectConfig{SlackChannel: "channel"},
+		ProjectConfig: scanner.ProjectConfig{ReportToSlackChannel: "channel"},
 	}
 
 	_ = PublishAsSpecificChannelSlackMessage([]scanner.Report{report}, mockSlackService)
@@ -70,7 +70,7 @@ func TestFormatSummary(t *testing.T) {
 		},
 	}
 
-	msgOpts := formatSummary(groupVulnReportsByMaxSeverityKind(report), len(report), []string{"path/to/group"}, []string{"path/to/project"})
+	msgOpts := formatSummary(groupVulnReportsByMaxSeverityKind(report), len(report), []string{"path/to/group", "path/to/project"})
 
 	assert.NotNil(t, msgOpts)
 	assert.Len(t, msgOpts, 1)

--- a/internal/scanner/vulnscanner.go
+++ b/internal/scanner/vulnscanner.go
@@ -50,8 +50,8 @@ type AcknowledgedVuln struct {
 }
 
 type ProjectConfig struct {
-	SlackChannel string             `toml:"slack-channel"`
-	Acknowledged []AcknowledgedVuln `toml:"acknowledged"`
+	ReportToSlackChannel string             `toml:"report-to-slack-channel"`
+	Acknowledged         []AcknowledgedVuln `toml:"acknowledged"`
 }
 
 // Report is the main report representation of a project vulnerability scan.

--- a/internal/slack/slack.go
+++ b/internal/slack/slack.go
@@ -14,18 +14,17 @@ type IService interface {
 }
 
 type service struct {
-	client                  iclient
-	isPublicChannelsEnabled bool
+	client iclient
 }
 
 // New creates a new Slack service
-func New(token string, isPublicChannelsEnabled bool, debug bool) (IService, error) {
+func New(token string, debug bool) (IService, error) {
 	slackClient := slack.New(token, slack.OptionDebug(debug))
 	if slackClient == nil {
 		return nil, errors.New("failed to create slack client")
 	}
 
-	s := service{&client{client: slackClient}, isPublicChannelsEnabled}
+	s := service{&client{client: slackClient}}
 
 	return &s, nil
 }
@@ -52,10 +51,7 @@ func (s *service) PostMessage(channelName string, options ...slack.MsgOption) (t
 func (s *service) findSlackChannel(channelName string) (channel *slack.Channel, err error) {
 	var nextCursor string
 	var channels []slack.Channel
-	var channelTypes = []string{"private_channel"}
-	if s.isPublicChannelsEnabled {
-		channelTypes = append(channelTypes, "public_channel")
-	}
+	var channelTypes = []string{"private_channel", "public_channel"}
 
 	for {
 		if channels, nextCursor, err = s.client.GetConversations(&slack.GetConversationsParameters{


### PR DESCRIPTION
This PR reworks the CLI interface as discussed in #17 

**What changed in the interface**
- removal of `testing` flag
- removal of `public-slack-channel` (rational: configurators of the cli should be responsible for using a public or private channel
- rename and group `gitlab-groups` and `gitlab-projects` under a generic `url` flag
  - This `--url` flag accepts lists of URLS which have a supported platform scheme, and a project or group as the path. For example `gitlab://path/to/my/group`, or `gitlab://path/to/my/namespace`, and soon to include `github://user/project`
- rename `report-slack-channel` to `report-to-slack-channel`
- rename `report-slack-project-channel` to `report-enable-project-report-to`
- rename `report-gitlab-issue` to `report-to-issue`
- add `report-to-email` which does nothing for the moment.
- adds some short aliases for `config` and `verbose`

**What changed in gitlab logic**
Now that paths can be _either_ a group _or_ a project, the logic was changed to:
1. Try getting the path as a group.
   - If it succeeds, return that group's projects
   - If it fails, try getting the path as a project

The nice thing is that I found out that the gitlab API accepts the _path_ instead of an actual ID, and this simplifies the gitlab logic we had in place 😄 (before we were using the search API to actually find the group, in order to use its real ID, etc.. so we were making more API calls than we now are)

```
NAME:
   sheriff patrol - Tell sheriff to patrol a GitLab group looking for vulnerabilities

USAGE:
   sheriff patrol [command options]

DESCRIPTION:
   Sheriff will patrol a GitLab group looking for vulnerabilities in the dependencies of the projects in the group.

   You can configure the behavior of Sheriff by providing various flags. (see OPTIONS)
   In addition, you can create a configuration file named sheriff.toml in the current directory. Sheriff will look for this file by default, but you can specify a different configuration file with the --config flag.
   This file is formatted in TOML and can contain any of the flags that can be set on the command line under the 'Reporting' category.


OPTIONS:
   --config value, -c value  (default: "sheriff.toml")

   Miscellaneous:

   --verbose, -v  Enable verbose logging (default: false)

   Reporting (configurable by file):

   --report-enable-project-report-to                    Enable project-level configuration for '--report-to'. (default: true)
   --report-to-email value [ --report-to-email value ]  Enable reporting to the provided list of emails
   --report-to-issue                                    Enable or disable reporting to the project's issue on the associated platform (gitlab, github, ...) (default: false)
   --report-to-slack-channel value                      Enable reporting to the provided slack channel
   --silent                                             Disable report output to stdout. (default: false)

   Scanning (configurable by file):

   --url value [ --url value ]  Groups and projects to scan for vulnerabilities (list argument which can be repeated)

   Tokens:

   --gitlab-token value  Token to access the Gitlab API. [$GITLAB_TOKEN]
   --slack-token value   Token to access the Slack API. [$SLACK_TOKEN]
```