### PR TITLE
ci: use goreleaser to generate binaries

### DIFF
--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -5,20 +5,27 @@ on:
     tags:
       - "v*.*.*"
 
-
 permissions:
   contents: write
 
 jobs:
-  build:
+  release:
     runs-on: ubuntu-latest
     steps:
-    - uses: actions/checkout@v4
-    - name: Release
-      uses: softprops/action-gh-release@v2
-      with:
-        generate_release_notes: true
-        token: "${{ secrets.GITHUB_TOKEN }}"
+      - name: Checkout
+        uses: actions/checkout@v4
+      - name: Setup Go
+        uses: actions/setup-go@v5
+        with:
+          go-version: 1.22.x
+      - name: Run goreleaser
+        uses: goreleaser/goreleaser-action@v4
+        with:
+          distribution: goreleaser
+          version: v1.17.2
+          args: release --clean
+        env:
+          GITHUB_TOKEN: ${{secrets.GITHUB_TOKEN}}
   docker:
     runs-on: ubuntu-latest
     steps:


### PR DESCRIPTION
I am not entirely sure if this will work, and how it will look.

docs: https://goreleaser.com/
example: https://github.com/jesseduffield/lazygit/blob/master/.github/workflows/cd.yml