### PR TITLE
feat: fail-fast in case of missing scanners

### DIFF
--- a/README.md
+++ b/README.md
@@ -28,7 +28,7 @@ Sheriff is a tool to scan repositories and generate security reports.
 ## Quick Usage
 
 ```sh
-sheriff patrol --gitlab-groups your-namespace-or-group --report-gitlab-issue
+sheriff patrol --url gitlab://your-namespace-or-group --report-to-issue
 ```
 
 ## How it works

--- a/internal/scanner/osv.go
+++ b/internal/scanner/osv.go
@@ -12,14 +12,14 @@ import (
 	gogitlab "github.com/xanzy/go-gitlab"
 )
 
-const osvTimeout = 30 * time.Second
-
 type osvReferenceKind string
 
 const (
-	AdvisoryKind osvReferenceKind = "ADVISORY"
-	WebKind      osvReferenceKind = "WEB"
-	PackageKind  osvReferenceKind = "PACKAGE"
+	OsvCommandName                  = "osv-scanner"
+	AdvisoryKind   osvReferenceKind = "ADVISORY"
+	WebKind        osvReferenceKind = "WEB"
+	PackageKind    osvReferenceKind = "PACKAGE"
+	osvTimeout                      = 30 * time.Second
 )
 
 type osvSource struct {
@@ -109,7 +109,7 @@ func (s *osvScanner) Scan(dir string) (*OsvReport, error) {
 
 	cmdOut, err := shell.ShellCommandRunner.Run(
 		shell.CommandInput{
-			Name:    "osv-scanner",
+			Name:    OsvCommandName,
 			Args:    []string{"-r", "--verbosity", "error", "--format", "json", dir},
 			Timeout: osvTimeout,
 		},


### PR DESCRIPTION
It is annoying that if you are missing `osv-scanner` and scan a big group, you realize after the whole goroutine fiesta has started and you have to ctrl+c.

I think this is better UX. 

If in the future we have more scanners (#15) we can decide then if there are optional scanners, if these will be warnings, or if we will skip them.

<img width="1286" alt="image" src="https://github.com/user-attachments/assets/7096d1d1-b5a1-4e73-ae60-f2ab7050b35c">

