### PR TITLE
fix: keep project-level config backwards-compatible

### DIFF
--- a/internal/patrol/config.go
+++ b/internal/patrol/config.go
@@ -28,5 +28,9 @@ func getConfiguration(filename string) (config scanner.ProjectConfig, found bool
 		log.Warn().Strs("keys", keys).Msg("Found undecoded keys in project configuration")
 	}
 
+	if config.SlackChannel != "" {
+		config.ReportToSlackChannel = config.SlackChannel
+	}
+
 	return config, true, nil
 }

--- a/internal/scanner/vulnscanner.go
+++ b/internal/scanner/vulnscanner.go
@@ -51,6 +51,7 @@ type AcknowledgedVuln struct {
 
 type ProjectConfig struct {
 	ReportToSlackChannel string             `toml:"report-to-slack-channel"`
+	SlackChannel         string             `toml:"slack-channel"` // TODO #27: Break in v1.0. Kept for backwards-compatibility
 	Acknowledged         []AcknowledgedVuln `toml:"acknowledged"`
 }
 


### PR DESCRIPTION
We have 1 project using the "old" configuration key.

We could break it now, but I want the change to be smooth since they are our first testers.
So I'd like to have the full list of potential breaking changes before asking them to change, just to make it easier