### PR TITLE
ci: change goreleaser changelog and attempt a non-shallow clone

### DIFF
--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -14,6 +14,8 @@ jobs:
     steps:
       - name: Checkout
         uses: actions/checkout@v4
+        with:
+          fetch-depth: 0
       - name: Setup Go
         uses: actions/setup-go@v5
         with:

--- a/.goreleaser.yml
+++ b/.goreleaser.yml
@@ -1,0 +1,3 @@
+changelog:
+  use: github-native
+  sort: asc


### PR DESCRIPTION
In our publish action it says: 
> running against a shallow clone - check your CI documentation at https://goreleaser.com/ci

I followed their docs there and included the fetch-depth (?)

I also added a goreleaser.yml with github-native changelog.
