### PR TITLE
refactor: use slices.SortFunc instead of sort.Slice

### DIFF
--- a/internal/patrol/patrol.go
+++ b/internal/patrol/patrol.go
@@ -2,6 +2,7 @@
 package patrol
 
 import (
+	"cmp"
 	"errors"
 	"fmt"
 	"os"
@@ -11,12 +12,12 @@ import (
 	"sheriff/internal/publish"
 	"sheriff/internal/scanner"
 	"sheriff/internal/slack"
-	"sort"
 	"sync"
 
 	"github.com/elliotchance/pie/v2"
 	"github.com/rs/zerolog/log"
 	gogitlab "github.com/xanzy/go-gitlab"
+	"golang.org/x/exp/slices"
 )
 
 const tempScanDir = "tmp_scans"
@@ -147,8 +148,8 @@ func (s *sheriffService) scanAndGetReports(locations []config.ProjectLocation) (
 		reports = append(reports, r)
 	}
 
-	sort.Slice(reports, func(i int, j int) bool {
-		return len(reports[i].Vulnerabilities) > len(reports[j].Vulnerabilities)
+	slices.SortFunc(reports, func(a, b scanner.Report) int {
+		return cmp.Compare(len(b.Vulnerabilities), len(a.Vulnerabilities))
 	})
 
 	return

--- a/internal/publish/to_gitlab.go
+++ b/internal/publish/to_gitlab.go
@@ -14,7 +14,7 @@ import (
 )
 
 // severityScoreOrder represents the order of SeverityScoreKind by their score in descending order
-// which is how we want to display it in the
+// which is how we want to display it in the Issue report
 var severityScoreOrder = getSeverityScoreOrder(scanner.SeverityScoreThresholds)
 
 // now is a function that returns the current time

--- a/internal/publish/to_slack.go
+++ b/internal/publish/to_slack.go
@@ -1,11 +1,12 @@
 package publish
 
 import (
+	"cmp"
 	"errors"
 	"fmt"
 	"sheriff/internal/scanner"
 	"sheriff/internal/slack"
-	"sort"
+	"slices"
 	"strings"
 	"sync"
 	"time"
@@ -235,8 +236,8 @@ func getSeverityScoreOrder(thresholds map[scanner.SeverityScoreKind]float64) []s
 	for kind := range thresholds {
 		kinds = append(kinds, kind)
 	}
-	sort.Slice(kinds, func(i, j int) bool {
-		return thresholds[kinds[i]] > thresholds[kinds[j]]
+	slices.SortFunc(kinds, func(a, b scanner.SeverityScoreKind) int {
+		return cmp.Compare(thresholds[b], thresholds[a])
 	})
 
 	return kinds


### PR DESCRIPTION
Nothing really interesting here, just following the[ docs of `sort.Slice`](https://pkg.go.dev/sort#Slice):

> Note: in many situations, the newer [slices.SortFunc](https://pkg.go.dev/slices#SortFunc) function is more ergonomic and runs faster.
