### PR TITLE
feat(#31): Mark outdated acknowledged vulnerabilities in the issue report

### DIFF
--- a/internal/patrol/patrol.go
+++ b/internal/patrol/patrol.go
@@ -213,15 +213,12 @@ func markVulnsAsAcknowledgedInReport(report *scanner.Report, config config.Proje
 // markOutdatedAcknowledgements marks configured acknowledged vulnerabilities as outdated in the report
 // A vulnerability is "outdated" if it is no longer present in the report.
 func markOutdatedAcknowledgements(report *scanner.Report, config config.ProjectConfig) {
+	var vulnCodes = make(map[string]bool, len(report.Vulnerabilities))
+	for _, vuln := range report.Vulnerabilities {
+		vulnCodes[vuln.Id] = true
+	}
 	for _, ack := range config.Acknowledged {
-		found := false
-		for _, v := range report.Vulnerabilities {
-			if v.Id == ack.Code {
-				found = true
-				break
-			}
-		}
-		if !found {
+		if !vulnCodes[ack.Code] {
 			log.Info().Str("ack", ack.Code).Msg("Acknowledged vulnerability is outdated")
 			report.OutdatedAcks = append(report.OutdatedAcks, ack.Code)
 		}

--- a/internal/patrol/patrol_test.go
+++ b/internal/patrol/patrol_test.go
@@ -155,6 +155,37 @@ func TestMarkVulnsAsAcknowledgedInReport(t *testing.T) {
 	assert.Equal(t, scanner.Critical, report.Vulnerabilities[1].SeverityScoreKind)
 }
 
+func TestMarkOutdatedAcknowledgements(t *testing.T) {
+	report := scanner.Report{
+		Vulnerabilities: []scanner.Vulnerability{
+			{
+				Id:                "CVE-1",
+				SeverityScoreKind: scanner.Critical,
+			},
+
+			{
+				Id:                "CVE-2",
+				SeverityScoreKind: scanner.Critical,
+			},
+		},
+	}
+	config := config.ProjectConfig{
+		Acknowledged: []config.AcknowledgedVuln{
+			{
+				Code: "CVE-1", // still relevant
+			},
+
+			{
+				Code: "CVE-3", // not in report (outdated)
+			},
+		},
+	}
+
+	markOutdatedAcknowledgements(&report, config)
+
+	assert.Equal(t, []string{"CVE-3"}, report.OutdatedAcks)
+}
+
 type mockGitlabService struct {
 	mock.Mock
 }

--- a/internal/publish/to_gitlab.go
+++ b/internal/publish/to_gitlab.go
@@ -88,6 +88,23 @@ func formatGitlabIssue(r scanner.Report) (mdReport string) {
 		}
 	}
 
+	// Add outdated acknowledgements section
+	mdReport += formatOutdatedAcks(r.OutdatedAcks)
+
+	return
+}
+
+// formatOutdatedAcks formats the outdated acknowledgements as a markdown section
+func formatOutdatedAcks(outdatedAcks []string) (md string) {
+	if len(outdatedAcks) == 0 {
+		return
+	}
+
+	md = "\n\n-------\n\n### Outdated Acknowledgements\n"
+	md += "\n💡 These vulnerabilities were acknowledged in the project configuration but are no longer relevant.\n\n"
+	for _, ack := range outdatedAcks {
+		md += fmt.Sprintf("- `%v`\n", ack)
+	}
 	return
 }
 

--- a/internal/scanner/vulnscanner.go
+++ b/internal/scanner/vulnscanner.go
@@ -52,8 +52,9 @@ type Report struct {
 	ProjectConfig   config.ProjectConfig // Contains the project-level configuration that users of sheriff may have in their repository
 	IsVulnerable    bool
 	Vulnerabilities []Vulnerability
-	IssueUrl        string // URL of the GitLab issue. Conditionally set if --gitlab-issue is passed
-	Error           bool   // Conditionally set if an error occurred during the scan
+	IssueUrl        string   // URL of the GitLab issue. Conditionally set if --gitlab-issue is passed
+	Error           bool     // Conditionally set if an error occurred during the scan
+	OutdatedAcks    []string // Vulnerabilities in the project configuration that are no longer present in the report
 }
 
 // VulnScanner is an interface for any vulnerability scanner


### PR DESCRIPTION
For now only in the issue report.

Do we want it somewhere else?
- For sure in the summary Slack report we don't: the audience for that are not the ones with power to fix it.
- For the project-specific one in Slack... maybe? Not sure. I think Gitlab is the best place.


Looks like this:
<img width="719" alt="image" src="https://github.com/user-attachments/assets/2a77c225-b9d8-410f-b75d-fdfc0af839f9" />

closes #31 
