### PR TITLE
ci: fix labeler workflow

### DIFF
--- a/.github/workflows/conventional-label.yaml
+++ b/.github/workflows/conventional-label.yaml
@@ -1,5 +1,8 @@
+# Warning, do not check out untrusted code with
+# the pull_request_target event.
 on:
-  pull_request:
+  pull_request_target:
+    types: [ opened, edited ]
 name: conventional-release-labels
 jobs:
   label:


### PR DESCRIPTION
Fixes the labeler workflow by adding specific permissions

https://github.com/bcoe/conventional-release-labels/issues/38
