### PR TITLE
fix: project config compatibility

### DIFF
--- a/internal/config/project.go
+++ b/internal/config/project.go
@@ -29,5 +29,9 @@ func GetProjectConfiguration(projectName string, dir string) (config ProjectConf
 		log.Info().Str("project", projectName).Msg("No project configuration found. Using default")
 	}
 
+	if config.SlackChannel != "" {
+		config.ReportToSlackChannel = config.SlackChannel
+	}
+
 	return
 }


### PR DESCRIPTION
This backwards-compatible config key was lost when migrating the config package.