### PR TITLE
chore: match project config with clli config

### DIFF
--- a/internal/config/project.go
+++ b/internal/config/project.go
@@ -13,10 +13,18 @@ type AcknowledgedVuln struct {
 	Reason string `toml:"reason"`
 }
 
+type ProjectReportTo struct {
+	SlackChannel string `toml:"slack-channel"`
+}
+
+type ProjectReport struct {
+	To ProjectReportTo `toml:"to"`
+}
+
 type ProjectConfig struct {
-	ReportToSlackChannel string             `toml:"report-to-slack-channel"`
-	SlackChannel         string             `toml:"slack-channel"` // TODO #27: Break in v1.0. Kept for backwards-compatibility
-	Acknowledged         []AcknowledgedVuln `toml:"acknowledged"`
+	Report       ProjectReport      `toml:"report"`
+	SlackChannel string             `toml:"slack-channel"` // TODO #27: Break in v1.0. Kept for backwards-compatibility
+	Acknowledged []AcknowledgedVuln `toml:"acknowledged"`
 }
 
 func GetProjectConfiguration(projectName string, dir string) (config ProjectConfig) {
@@ -30,7 +38,7 @@ func GetProjectConfiguration(projectName string, dir string) (config ProjectConf
 	}
 
 	if config.SlackChannel != "" {
-		config.ReportToSlackChannel = config.SlackChannel
+		config.Report.To.SlackChannel = config.SlackChannel
 	}
 
 	return

--- a/internal/config/project_test.go
+++ b/internal/config/project_test.go
@@ -12,7 +12,7 @@ func TestGetConfiguration(t *testing.T) {
 		foldername string
 		wantConfig ProjectConfig
 	}{
-		{"valid", ProjectConfig{ReportToSlackChannel: "the-devils-slack-channel"}},
+		{"valid", ProjectConfig{Report: ProjectReport{To: ProjectReportTo{SlackChannel: "the-devils-slack-channel"}}}},
 		{"invalid", ProjectConfig{}},
 		{"nonexistent", ProjectConfig{}},
 		{"valid_with_ack", ProjectConfig{Acknowledged: []AcknowledgedVuln{{Code: "CSV111", Reason: "not relevant"}, {Code: "CSV222", Reason: ""}}}},

--- a/internal/config/testdata/project/valid/sheriff.toml
+++ b/internal/config/testdata/project/valid/sheriff.toml
@@ -1,1 +1,2 @@
-report-to-slack-channel = "the-devils-slack-channel"
+[report.to]
+slack-channel = "the-devils-slack-channel"

--- a/internal/publish/to_slack.go
+++ b/internal/publish/to_slack.go
@@ -47,7 +47,7 @@ func PublishAsGeneralSlackMessage(channelNames []string, reports []scanner.Repor
 }
 
 func PublishAsSpecificChannelSlackMessage(reports []scanner.Report, s slack.IService) (warn error) {
-	configuredReports := pie.Filter(reports, func(r scanner.Report) bool { return r.ProjectConfig.ReportToSlackChannel != "" })
+	configuredReports := pie.Filter(reports, func(r scanner.Report) bool { return r.ProjectConfig.Report.To.SlackChannel != "" })
 
 	var wg sync.WaitGroup
 	for _, report := range configuredReports {
@@ -57,10 +57,10 @@ func PublishAsSpecificChannelSlackMessage(reports []scanner.Report, s slack.ISer
 			defer wg.Done()
 			message := formatSpecificChannelSlackMessage(report)
 
-			_, err := s.PostMessage(report.ProjectConfig.ReportToSlackChannel, message...)
+			_, err := s.PostMessage(report.ProjectConfig.Report.To.SlackChannel, message...)
 			if err != nil {
-				log.Error().Err(err).Str("channel", report.ProjectConfig.ReportToSlackChannel).Msg("Failed to post slack report")
-				err = fmt.Errorf("failed to post slack report to channel %v", report.ProjectConfig.ReportToSlackChannel)
+				log.Error().Err(err).Str("channel", report.ProjectConfig.Report.To.SlackChannel).Msg("Failed to post slack report")
+				err = fmt.Errorf("failed to post slack report to channel %v", report.ProjectConfig.Report.To.SlackChannel)
 				warn = errors.Join(err, warn)
 			}
 		}()

--- a/internal/publish/to_slack_test.go
+++ b/internal/publish/to_slack_test.go
@@ -62,7 +62,7 @@ func TestPublishAsSpecificChannelSlackMessage(t *testing.T) {
 				Id: "CVE-2021-1234",
 			},
 		},
-		ProjectConfig: config.ProjectConfig{ReportToSlackChannel: "channel"},
+		ProjectConfig: config.ProjectConfig{Report: config.ProjectReport{To: config.ProjectReportTo{SlackChannel: "channel"}}},
 	}
 
 	_ = PublishAsSpecificChannelSlackMessage([]scanner.Report{report}, mockSlackService)


### PR DESCRIPTION
Changes the project config to match the cli config

Before:
```toml
report-to-slack-channel = "my-slack-channel"
```

After: 
```toml
[report.to]
slack-channel = "my-slack-channel"
```