### PR TITLE
refactor(#9): move gitlab logic to specific repository package

### DIFF
--- a/internal/config/patrol.go
+++ b/internal/config/patrol.go
@@ -4,19 +4,13 @@ import (
 	"errors"
 	"fmt"
 	"net/url"
+	"sheriff/internal/repo"
 
 	zerolog "github.com/rs/zerolog/log"
 )
 
-type PlatformType string
-
-const (
-	Gitlab PlatformType = "gitlab"
-	Github PlatformType = "github"
-)
-
 type ProjectLocation struct {
-	Type PlatformType
+	Type repo.PlatformType
 	Path string
 }
 
@@ -130,9 +124,9 @@ func parseTargets(targets []string) ([]ProjectLocation, error) {
 			return nil, fmt.Errorf("target missing platform scheme %v", t)
 		}
 
-		if parsed.Scheme == string(Github) {
+		if parsed.Scheme == string(repo.Github) {
 			return nil, fmt.Errorf("github is currently unsupported, but is on our roadmap 😃") // TODO #9
-		} else if parsed.Scheme != string(Gitlab) {
+		} else if parsed.Scheme != string(repo.Gitlab) {
 			return nil, fmt.Errorf("unsupported platform %v", parsed.Scheme)
 		}
 
@@ -142,7 +136,7 @@ func parseTargets(targets []string) ([]ProjectLocation, error) {
 		}
 
 		locations[i] = ProjectLocation{
-			Type: PlatformType(parsed.Scheme),
+			Type: repo.PlatformType(parsed.Scheme),
 			Path: path,
 		}
 	}

--- a/internal/config/patrol_test.go
+++ b/internal/config/patrol_test.go
@@ -1,6 +1,7 @@
 package config
 
 import (
+	"sheriff/internal/repo"
 	"testing"
 
 	"github.com/stretchr/testify/assert"
@@ -8,7 +9,7 @@ import (
 
 func TestGetPatrolConfiguration(t *testing.T) {
 	want := PatrolConfig{
-		Locations:             []ProjectLocation{{Type: Gitlab, Path: "group1"}, {Type: Gitlab, Path: "group2/project1"}},
+		Locations:             []ProjectLocation{{Type: repo.Gitlab, Path: "group1"}, {Type: repo.Gitlab, Path: "group2/project1"}},
 		ReportToEmails:        []string{"some-email@gmail.com"},
 		ReportToSlackChannels: []string{"report-slack-channel"},
 		ReportToIssue:         true,
@@ -28,7 +29,7 @@ func TestGetPatrolConfiguration(t *testing.T) {
 
 func TestGetPatrolConfigurationCLIOverridesFile(t *testing.T) {
 	want := PatrolConfig{
-		Locations:             []ProjectLocation{{Type: Gitlab, Path: "group1"}, {Type: Gitlab, Path: "group2/project1"}},
+		Locations:             []ProjectLocation{{Type: repo.Gitlab, Path: "group1"}, {Type: repo.Gitlab, Path: "group2/project1"}},
 		ReportToEmails:        []string{"email@gmail.com", "other@gmail.com"},
 		ReportToSlackChannels: []string{"other-slack-channel"},
 		ReportToIssue:         false,

--- a/internal/publish/to_console.go
+++ b/internal/publish/to_console.go
@@ -32,7 +32,7 @@ func formatReportsMessageForConsole(scanReports []scanner.Report) string {
 	r.WriteString(fmt.Sprintf("Total number of projects scanned: %v\n", len(scanReports)))
 	for _, report := range scanReports {
 		r.WriteString(fmt.Sprintln("---------------------------------"))
-		r.WriteString(fmt.Sprintf("%v\n", report.Project.PathWithNamespace))
+		r.WriteString(fmt.Sprintf("%v\n", report.Project.Path))
 		r.WriteString(fmt.Sprintf("\tProject URL: %v\n", report.Project.WebURL))
 		r.WriteString(fmt.Sprintf("\tNumber of vulnerabilities: %v\n", len(report.Vulnerabilities)))
 	}

--- a/internal/publish/to_console_test.go
+++ b/internal/publish/to_console_test.go
@@ -1,17 +1,17 @@
 package publish
 
 import (
+	"sheriff/internal/repo"
 	"sheriff/internal/scanner"
 	"testing"
 
 	"github.com/stretchr/testify/assert"
-	gogitlab "github.com/xanzy/go-gitlab"
 )
 
 func TestFormatReportMessageForConsole(t *testing.T) {
 	reports := []scanner.Report{
 		{
-			Project: gogitlab.Project{
+			Project: repo.Project{
 				Name:   "project1",
 				WebURL: "http://example.com",
 			},
@@ -27,7 +27,7 @@ func TestFormatReportMessageForConsole(t *testing.T) {
 			},
 		},
 		{
-			Project: gogitlab.Project{
+			Project: repo.Project{
 				Name:   "project2",
 				WebURL: "http://example2.com",
 			},

--- a/internal/publish/to_gitlab.go
+++ b/internal/publish/to_gitlab.go
@@ -3,7 +3,7 @@ package publish
 import (
 	"errors"
 	"fmt"
-	"sheriff/internal/gitlab"
+	"sheriff/internal/repo"
 	"sheriff/internal/scanner"
 	"strconv"
 	"sync"
@@ -22,7 +22,7 @@ var now = time.Now
 
 // PublishAsGitlabIssues creates or updates GitLab Issue reports for the given reports
 // It will add the Issue URL to the Report if it was created or updated successfully
-func PublishAsGitlabIssues(reports []scanner.Report, s gitlab.IService) (warn error) {
+func PublishAsGitlabIssues(reports []scanner.Report, s repo.IService) (warn error) {
 	var wg sync.WaitGroup
 	for i := 0; i < len(reports); i++ {
 		wg.Add(1)
@@ -30,16 +30,16 @@ func PublishAsGitlabIssues(reports []scanner.Report, s gitlab.IService) (warn er
 			defer wg.Done()
 			if reports[i].IsVulnerable {
 				if issue, err := s.OpenVulnerabilityIssue(reports[i].Project, formatGitlabIssue(reports[i])); err != nil {
-					log.Error().Err(err).Str("project", reports[i].Project.Name).Msg("Failed to open or update issue")
-					err = fmt.Errorf("failed to open or update issue for project %v", reports[i].Project.Name)
+					log.Error().Err(err).Str("project", reports[i].Project.Path).Msg("Failed to open or update issue")
+					err = fmt.Errorf("failed to open or update issue for project %v", reports[i].Project.Path)
 					warn = errors.Join(err, warn)
 				} else {
 					reports[i].IssueUrl = issue.WebURL
 				}
 			} else {
 				if err := s.CloseVulnerabilityIssue(reports[i].Project); err != nil {
-					log.Error().Err(err).Str("project", reports[i].Project.Name).Msg("Failed to close issue")
-					err = fmt.Errorf("failed to close issue for project %v", reports[i].Project.Name)
+					log.Error().Err(err).Str("project", reports[i].Project.Path).Msg("Failed to close issue")
+					err = fmt.Errorf("failed to close issue for project %v", reports[i].Project.Path)
 					warn = errors.Join(err, warn)
 				}
 			}

--- a/internal/publish/to_gitlab_test.go
+++ b/internal/publish/to_gitlab_test.go
@@ -1,13 +1,13 @@
 package publish
 
 import (
+	"sheriff/internal/repo"
 	"sheriff/internal/scanner"
 	"testing"
 	"time"
 
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/mock"
-	"github.com/xanzy/go-gitlab"
 )
 
 // Severities are grouped by severity score kind
@@ -164,7 +164,7 @@ func TestMarkdownBoolean(t *testing.T) {
 
 func TestPublishAsGitlabIssues(t *testing.T) {
 	mockGitlabService := &mockGitlabService{}
-	mockGitlabService.On("OpenVulnerabilityIssue", mock.Anything, mock.Anything).Return(&gitlab.Issue{WebURL: "https://my-issue.com"}, nil)
+	mockGitlabService.On("OpenVulnerabilityIssue", mock.Anything, mock.Anything).Return(&repo.Issue{WebURL: "https://my-issue.com"}, nil)
 	reports := []scanner.Report{
 		{
 			IsVulnerable: true,
@@ -206,17 +206,17 @@ type mockGitlabService struct {
 	mock.Mock
 }
 
-func (c *mockGitlabService) GetProjectList(paths []string) ([]gitlab.Project, error) {
+func (c *mockGitlabService) GetProjectList(paths []string) ([]repo.Project, error) {
 	args := c.Called(paths)
-	return args.Get(0).([]gitlab.Project), args.Error(1)
+	return args.Get(0).([]repo.Project), args.Error(1)
 }
 
-func (c *mockGitlabService) CloseVulnerabilityIssue(project gitlab.Project) error {
+func (c *mockGitlabService) CloseVulnerabilityIssue(project repo.Project) error {
 	args := c.Called(project)
 	return args.Error(0)
 }
 
-func (c *mockGitlabService) OpenVulnerabilityIssue(project gitlab.Project, report string) (*gitlab.Issue, error) {
+func (c *mockGitlabService) OpenVulnerabilityIssue(project repo.Project, report string) (*repo.Issue, error) {
 	args := c.Called(project, report)
-	return args.Get(0).(*gitlab.Issue), args.Error(1)
+	return args.Get(0).(*repo.Issue), args.Error(1)
 }

--- a/internal/publish/to_slack.go
+++ b/internal/publish/to_slack.go
@@ -82,7 +82,7 @@ func formatSpecificChannelSlackMessage(report scanner.Report) []goslack.MsgOptio
 
 	// Texts
 	title := fmt.Sprintf("Sheriff Report %v", time.Now().Format("2006-01-02"))
-	subtitle := fmt.Sprintf("Project: <%s|*%s*>", report.Project.WebURL, report.Project.PathWithNamespace)
+	subtitle := fmt.Sprintf("Project: <%s|*%s*>", report.Project.WebURL, report.Project.Path)
 	var subtitleFullReport string
 	if report.IssueUrl != "" {
 		subtitleFullReport = fmt.Sprintf("Full report: <%s|*Full report*>", report.IssueUrl)

--- a/internal/publish/to_slack_test.go
+++ b/internal/publish/to_slack_test.go
@@ -2,13 +2,13 @@ package publish
 
 import (
 	"sheriff/internal/config"
+	"sheriff/internal/repo"
 	"sheriff/internal/scanner"
 	"testing"
 
 	"github.com/slack-go/slack"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/mock"
-	gogitlab "github.com/xanzy/go-gitlab"
 )
 
 func TestPublishAsGeneralSlackMessage(t *testing.T) {
@@ -102,7 +102,7 @@ func TestFormatReportMessage(t *testing.T) {
 	reportBySeverityKind := map[scanner.SeverityScoreKind][]scanner.Report{
 		scanner.Critical: {
 			{
-				Project: gogitlab.Project{
+				Project: repo.Project{
 					Name:   "project1",
 					WebURL: "http://example.com",
 				},
@@ -118,7 +118,7 @@ func TestFormatReportMessage(t *testing.T) {
 		},
 		scanner.High: {
 			{
-				Project: gogitlab.Project{
+				Project: repo.Project{
 					Name:   "project2",
 					WebURL: "http://example2.com",
 				},

--- a/internal/repo/gitlab_client.go
+++ b/internal/repo/gitlab_client.go
@@ -1,5 +1,5 @@
 // Package gitlab provides a GitLab service to interact with the GitLab API.
-package gitlab
+package repo
 
 // This client is a thin wrapper around the go-gitlab library. It provides an interface to the GitLab client
 // The main purpose of this client is to provide an interface to the GitLab client which can be mocked in tests.

--- a/internal/repo/repo.go
+++ b/internal/repo/repo.go
@@ -1,0 +1,34 @@
+package repo
+
+const VulnerabilityIssueTitle = "Sheriff - 🚨 Vulnerability report"
+
+type PlatformType string
+
+const (
+	Gitlab PlatformType = "gitlab"
+	Github PlatformType = "github"
+)
+
+type Project struct {
+	ID       int
+	Name     string
+	Path     string
+	WebURL   string
+	RepoUrl  string
+	Platform string
+}
+
+type Issue struct {
+	ID       int
+	Title    string
+	WebURL   string
+	Open     bool
+	Platform string
+}
+
+// IService is the interface of the GitLab service as needed by sheriff
+type IService interface {
+	GetProjectList(paths []string) (projects []Project, warn error)
+	CloseVulnerabilityIssue(project Project) error
+	OpenVulnerabilityIssue(project Project, report string) (*Issue, error)
+}

--- a/internal/scanner/osv.go
+++ b/internal/scanner/osv.go
@@ -3,13 +3,13 @@ package scanner
 import (
 	"encoding/json"
 	"path/filepath"
+	"sheriff/internal/repo"
 	"sheriff/internal/shell"
 	"strconv"
 	"time"
 
 	"github.com/elliotchance/pie/v2"
 	"github.com/rs/zerolog/log"
-	gogitlab "github.com/xanzy/go-gitlab"
 )
 
 type osvReferenceKind string
@@ -136,7 +136,7 @@ func (s *osvScanner) Scan(dir string) (*OsvReport, error) {
 }
 
 // GenerateReport generates a Report struct from the OsvReport.
-func (s *osvScanner) GenerateReport(p gogitlab.Project, r *OsvReport) Report {
+func (s *osvScanner) GenerateReport(p repo.Project, r *OsvReport) Report {
 	if r == nil {
 		return Report{
 			Project:         p,

--- a/internal/scanner/osv_test.go
+++ b/internal/scanner/osv_test.go
@@ -1,6 +1,7 @@
 package scanner
 
 import (
+	"sheriff/internal/repo"
 	"sheriff/internal/shell"
 	"testing"
 
@@ -8,7 +9,6 @@ import (
 	"os"
 
 	"github.com/stretchr/testify/assert"
-	"github.com/xanzy/go-gitlab"
 )
 
 func TestReadOSVJson(t *testing.T) {
@@ -96,7 +96,7 @@ func (m *mockCommandRunner) Run(shell.CommandInput) (shell.CommandOutput, error)
 func TestGenerateReportOSV(t *testing.T) {
 	mockReport := createMockReport("10.0")
 	s := osvScanner{}
-	got := s.GenerateReport(gitlab.Project{}, mockReport)
+	got := s.GenerateReport(repo.Project{}, mockReport)
 
 	assert.NotNil(t, got)
 	assert.Len(t, got.Vulnerabilities, 1)
@@ -132,7 +132,7 @@ func TestGenerateReportOSVHasCorrectSeverityKind(t *testing.T) {
 	for input, want := range testCases {
 		t.Run(input, func(t *testing.T) {
 			mockReport := createMockReport(input)
-			got := s.GenerateReport(gitlab.Project{}, mockReport)
+			got := s.GenerateReport(repo.Project{}, mockReport)
 
 			assert.NotNil(t, got)
 			assert.Equal(t, want, got.Vulnerabilities[0].SeverityScoreKind)
@@ -156,7 +156,7 @@ func TestReportContainsHasAvailableFix(t *testing.T) {
 			},
 		},
 	})
-	got := s.GenerateReport(gitlab.Project{}, mockReport)
+	got := s.GenerateReport(repo.Project{}, mockReport)
 
 	assert.NotNil(t, got)
 	assert.Len(t, got.Vulnerabilities, 1)

--- a/internal/scanner/vulnscanner.go
+++ b/internal/scanner/vulnscanner.go
@@ -3,8 +3,7 @@ package scanner
 
 import (
 	"sheriff/internal/config"
-
-	gogitlab "github.com/xanzy/go-gitlab"
+	"sheriff/internal/repo"
 )
 
 type SeverityScoreKind string
@@ -48,7 +47,7 @@ type Vulnerability struct {
 
 // Report is the main report representation of a project vulnerability scan.
 type Report struct {
-	Project         gogitlab.Project
+	Project         repo.Project
 	ProjectConfig   config.ProjectConfig // Contains the project-level configuration that users of sheriff may have in their repository
 	IsVulnerable    bool
 	Vulnerabilities []Vulnerability
@@ -62,5 +61,5 @@ type VulnScanner[T any] interface {
 	// Scan runs a vulnerability scan on the given directory
 	Scan(dir string) (*T, error)
 	// GenerateReport maps the report from the scanner to our internal representation of vulnerability reports.
-	GenerateReport(p gogitlab.Project, r *T) Report
+	GenerateReport(p repo.Project, r *T) Report
 }


### PR DESCRIPTION
A first step to adding github is to isolate gitlab. This PR replaces all uses of `https://pkg.go.dev/github.com/xanzy/go-gitlab#section-readme` with generic types in our `repo` package, so they can be used regardless of the type of repository host.

- Renames `gitlab` package to `repo`
- Moves common "repo" types to a `repo.go` file in which we have the common service interface & structs (Project, Issue)
- Refactors `gitlab.go` to implement the common interface
- Refactors the rest of the CLI to use the common interface rather than the specific gitlab structs

With this change to add github I expect we will need to:
1. Create a new `repo/github.go` service which implements the common interface
2. Add logic in `patrol` to provide a different repository service based on the path type (gitlab vs github)