### PR TITLE
fix: summary report severity count

### DIFF
--- a/internal/publish/to_issue.go
+++ b/internal/publish/to_issue.go
@@ -67,7 +67,9 @@ func severityBiggerThan(a string, b string) bool {
 func groupVulnReportsByMaxSeverityKind(reports []scanner.Report) map[scanner.SeverityScoreKind][]scanner.Report {
 	vulnerableReports := pie.Filter(reports, func(r scanner.Report) bool { return r.IsVulnerable })
 	groupedVulnerabilities := pie.GroupBy(vulnerableReports, func(r scanner.Report) scanner.SeverityScoreKind {
-		maxSeverity := pie.SortUsing(r.Vulnerabilities, func(a, b scanner.Vulnerability) bool { return a.Severity > b.Severity })[0]
+		maxSeverity := pie.SortUsing(r.Vulnerabilities, func(a, b scanner.Vulnerability) bool {
+			return scanner.SeverityScoreThresholds[a.SeverityScoreKind] > scanner.SeverityScoreThresholds[b.SeverityScoreKind]
+		})[0]
 
 		return maxSeverity.SeverityScoreKind
 	})

--- a/internal/publish/to_slack.go
+++ b/internal/publish/to_slack.go
@@ -20,10 +20,10 @@ import (
 func PublishAsGeneralSlackMessage(channelNames []string, reports []scanner.Report, paths []string, s slack.IService) error {
 	var wg sync.WaitGroup
 	errChan := make(chan error, len(channelNames))
-	vulnerableReportsBySeverityKind := groupVulnReportsByMaxSeverityKind(reports)
+	vulnerableReportsByMaxSeverityKind := groupVulnReportsByMaxSeverityKind(reports)
 
-	summary := formatSummary(vulnerableReportsBySeverityKind, len(reports), paths)
-	threadMsgs := formatReportMessage(vulnerableReportsBySeverityKind)
+	summary := formatSummary(vulnerableReportsByMaxSeverityKind, len(reports), paths)
+	threadMsgs := formatReportMessage(vulnerableReportsByMaxSeverityKind)
 	for _, slackChannel := range channelNames {
 		log.Info().Str("slackChannel", slackChannel).Msg("Posting report to slack channel")
 		wg.Add(1)


### PR DESCRIPTION
Fixes a bug where projects that have "acknowledged" vulnerabilities only show up in the acknowledged section of the general report, thus hiding that they still make have critical/high vulnerabilities.

Vulnerabilities should be sorted by severity kind instead of severity score. This is because the acknowledged kind is computed by us, and overrides the actual score since we deem it AOK

I did not add any tests, at this point it is not simple... https://github.com/elementsinteractive/sheriff/issues/49