### PR TITLE
fix: scan directory should use slug

### DIFF
--- a/internal/patrol/patrol.go
+++ b/internal/patrol/patrol.go
@@ -179,7 +179,7 @@ func (s *sheriffService) getProjectList(locs []config.ProjectLocation) (projects
 
 // scanProject scans a project for vulnerabilities using the osv scanner.
 func (s *sheriffService) scanProject(project repository.Project) (report *scanner.Report, err error) {
-	dir, err := os.MkdirTemp(tempScanDir, fmt.Sprintf("%v-", project.Name))
+	dir, err := os.MkdirTemp(tempScanDir, fmt.Sprintf("%v-", project.Slug))
 	if err != nil {
 		return nil, errors.Join(errors.New("failed to create project temporary directory"), err)
 	}

--- a/internal/repository/github/github.go
+++ b/internal/repository/github/github.go
@@ -191,6 +191,7 @@ func mapGithubProject(r github.Repository) repository.Project {
 		ID:         int(valueOrEmpty(r.ID)),
 		Name:       valueOrEmpty(r.Name),
 		Path:       valueOrEmpty(r.FullName),
+		Slug:       valueOrEmpty(r.Name),
 		WebURL:     valueOrEmpty(r.HTMLURL),
 		RepoUrl:    valueOrEmpty(r.HTMLURL),
 		Repository: repository.Github,

--- a/internal/repository/gitlab/gitlab.go
+++ b/internal/repository/gitlab/gitlab.go
@@ -320,6 +320,7 @@ func mapProject(p gitlab.Project) repository.Project {
 	return repository.Project{
 		ID:         p.ID,
 		Name:       p.Name,
+		Slug:       p.Path,
 		Path:       p.PathWithNamespace,
 		WebURL:     p.WebURL,
 		RepoUrl:    p.HTTPURLToRepo,

--- a/internal/repository/repository.go
+++ b/internal/repository/repository.go
@@ -12,6 +12,7 @@ const (
 type Project struct {
 	ID         int
 	Name       string
+	Slug       string
 	Path       string
 	WebURL     string
 	RepoUrl    string


### PR DESCRIPTION
This avoids spaces & other characters which don't always play well in file paths