### PR TITLE
feat: ignore project list

### DIFF
--- a/README.md
+++ b/README.md
@@ -25,6 +25,7 @@ Sheriff is a tool to scan repositories and generate security reports.
       - [verbose](#verbose)
     - [Scanning](#scanning)
       - [targets](#targets)
+      - [ignored](#ignored)
     - [Reporting](#reporting)
       - [report to issue](#report-to-issue)
       - [report to email (TODO #12)](#report-to-email-todo-12)
@@ -165,6 +166,19 @@ The expected format of a target is `platform://path/to/your/group-or-project`
 
 For example:
 `--target gitlab://namespace/group --target github://organization/project`
+
+##### ignored
+
+| CLI options | File config |
+|---|---|
+| (repeatable) `--ignore` | `ignored` |
+
+Sets the list of groups and projects to be ignored from scanning.
+Useful when you have a `target` which is a group, but you want to ignore a specific project from that group.
+The expected format of a target is `platform://path/to/your/group-or-project`
+
+For example:
+`--ignore gitlab://namespace/group --ignore github://organization/project`
 
 #### Reporting
 

--- a/internal/cli/patrol.go
+++ b/internal/cli/patrol.go
@@ -27,6 +27,7 @@ const (
 const configFlag = "config"
 const verboseFlag = "verbose"
 const targetFlag = "target"
+const ignoreFlag = "ignore"
 const reportToEmailFlag = "report-to-email"
 const reportToIssueFlag = "report-to-issue"
 const reportToSlackChannel = "report-to-slack-channel"
@@ -54,6 +55,11 @@ var PatrolFlags = []cli.Flag{
 	&cli.StringSliceFlag{
 		Name:     targetFlag,
 		Usage:    "Groups and projects to scan for vulnerabilities (list argument which can be repeated)",
+		Category: string(Scanning),
+	},
+	&cli.StringSliceFlag{
+		Name:     ignoreFlag,
+		Usage:    "List of repositories or groups to ignore (list argument which can be repeated)",
 		Category: string(Scanning),
 	},
 	&cli.StringSliceFlag{
@@ -110,6 +116,7 @@ func PatrolAction(cCtx *cli.Context) error {
 	config, err := config.GetPatrolConfiguration(config.PatrolCLIOpts{
 		PatrolCommonOpts: config.PatrolCommonOpts{
 			Targets: getStringSliceIfSet(cCtx, targetFlag),
+			Ignored: getStringSliceIfSet(cCtx, ignoreFlag),
 			Report: config.PatrolReportOpts{
 				To: config.PatrolReportToOpts{
 					Issue:                 getBoolIfSet(cCtx, reportToIssueFlag),

--- a/internal/config/patrol.go
+++ b/internal/config/patrol.go
@@ -16,6 +16,7 @@ type ProjectLocation struct {
 
 type PatrolConfig struct {
 	Locations             []ProjectLocation
+	Ignored               []ProjectLocation
 	ReportToEmails        []string
 	ReportToSlackChannels []string
 	ReportToIssue         bool
@@ -39,6 +40,7 @@ type PatrolReportOpts struct {
 
 type PatrolCommonOpts struct {
 	Targets *[]string        `toml:"targets"`
+	Ignored *[]string        `toml:"ignored"`
 	Report  PatrolReportOpts `toml:"report"`
 }
 
@@ -86,6 +88,12 @@ func mergeConfigs(cliOpts PatrolCLIOpts, fileOpts PatrolFileOpts) (config Patrol
 		return config, errors.Join(errors.New("could not parse targets from CLI options"), err)
 	}
 
+	ignored := getCliOrFileOption(cliOpts.Ignored, fileOpts.Ignored, []string{})
+	parsedIgnored, err := parseTargets(ignored)
+	if err != nil {
+		return config, errors.Join(errors.New("could not parse targets from CLI options"), err)
+	}
+
 	config = PatrolConfig{
 		Locations:             parsedLocations,
 		ReportToIssue:         getCliOrFileOption(cliOpts.Report.To.Issue, fileOpts.Report.To.Issue, false),
@@ -94,6 +102,7 @@ func mergeConfigs(cliOpts PatrolCLIOpts, fileOpts PatrolFileOpts) (config Patrol
 		EnableProjectReportTo: getCliOrFileOption(cliOpts.Report.To.EnableProjectReportTo, fileOpts.Report.To.EnableProjectReportTo, false),
 		SilentReport:          getCliOrFileOption(cliOpts.Report.SilentReport, fileOpts.Report.SilentReport, false),
 		Verbose:               cliOpts.Verbose,
+		Ignored:               parsedIgnored,
 	}
 
 	return

--- a/internal/config/patrol_test.go
+++ b/internal/config/patrol_test.go
@@ -10,6 +10,7 @@ import (
 func TestGetPatrolConfiguration(t *testing.T) {
 	want := PatrolConfig{
 		Locations:             []ProjectLocation{{Type: repository.Gitlab, Path: "group1"}, {Type: repository.Gitlab, Path: "group2/project1"}},
+		Ignored:               []ProjectLocation{},
 		ReportToEmails:        []string{"some-email@gmail.com"},
 		ReportToSlackChannels: []string{"report-slack-channel"},
 		ReportToIssue:         true,
@@ -30,6 +31,7 @@ func TestGetPatrolConfiguration(t *testing.T) {
 func TestGetPatrolConfigurationCLIOverridesFile(t *testing.T) {
 	want := PatrolConfig{
 		Locations:             []ProjectLocation{{Type: repository.Gitlab, Path: "group1"}, {Type: repository.Gitlab, Path: "group2/project1"}},
+		Ignored:               []ProjectLocation{},
 		ReportToEmails:        []string{"email@gmail.com", "other@gmail.com"},
 		ReportToSlackChannels: []string{"other-slack-channel"},
 		ReportToIssue:         false,

--- a/internal/config/project.go
+++ b/internal/config/project.go
@@ -25,6 +25,7 @@ type ProjectConfig struct {
 	Report       ProjectReport      `toml:"report"`
 	SlackChannel string             `toml:"slack-channel"` // TODO #27: Break in v1.0. Kept for backwards-compatibility
 	Acknowledged []AcknowledgedVuln `toml:"acknowledged"`
+	Ignored      []string           `toml:"ignored"` // List of repositories or groups to ignore
 }
 
 func GetProjectConfiguration(projectName string, dir string) (config ProjectConfig) {


### PR DESCRIPTION
Adds a new CLI options `--ignore` and a new config list option `ignored = [...]` to list projects or groups to ignore, in a similar fashion to what is currently done with targets.

The idea behind this feature is that you may want to specify a group, but to ignore specific repositories or sub-groups within that group