### PR TITLE
fix: ignore fetched projects with ignore list

### DIFF
--- a/internal/patrol/patrol.go
+++ b/internal/patrol/patrol.go
@@ -145,17 +145,6 @@ func (s *sheriffService) scanAndGetReports(locations []config.ProjectLocation, i
 }
 
 func (s *sheriffService) getProjectList(locs []config.ProjectLocation, ignored []config.ProjectLocation) (projects []repository.Project, warn error) {
-	// Filter out locations that are in the ignored list
-	locs = pie.Filter(locs, func(loc config.ProjectLocation) bool {
-		return !slices.ContainsFunc(ignored, func(ignoredPath config.ProjectLocation) bool {
-			ignore := ignoredPath.Path == loc.Path && ignoredPath.Type == loc.Type
-			if ignore {
-				log.Info().Str("path", loc.Path).Msg("Ignoring project location as it is in the ignored list")
-			}
-			return ignore
-		})
-	})
-
 	gitlabLocs := pie.Map(
 		pie.Filter(locs, func(loc config.ProjectLocation) bool { return loc.Type == repository.Gitlab }),
 		func(loc config.ProjectLocation) string { return loc.Path },
@@ -184,6 +173,17 @@ func (s *sheriffService) getProjectList(locs []config.ProjectLocation, ignored [
 
 		projects = append(projects, githubProjects...)
 	}
+
+	// Filter out locations that are in the ignored list
+	projects = pie.Filter(projects, func(project repository.Project) bool {
+		return !slices.ContainsFunc(ignored, func(ignoredPath config.ProjectLocation) bool {
+			ignore := ignoredPath.Path == project.Path && ignoredPath.Type == project.Repository
+			if ignore {
+				log.Info().Str("path", project.Path).Msg("Ignoring project location as it is in the ignored list")
+			}
+			return ignore
+		})
+	})
 
 	return
 }

--- a/internal/patrol/patrol_test.go
+++ b/internal/patrol/patrol_test.go
@@ -194,7 +194,7 @@ func TestMarkOutdatedAcknowledgements(t *testing.T) {
 
 func TestGetProjectList_IgnoresProject(t *testing.T) {
 	mockClient := &mockClient{}
-	mockClient.On("GetProjectList", []string{"group/to/scan"}).Return([]repository.Project{{Name: "Hello World", RepoUrl: "https://gitlab.com/group/to/scan.git", Repository: repository.Gitlab}}, nil)
+	mockClient.On("GetProjectList", []string{"group/to/scan"}).Return([]repository.Project{{Path: "path/of/project", Repository: repository.Gitlab}}, nil)
 
 	mockRepoService := &mockRepoService{}
 	mockRepoService.On("Provide", repository.Gitlab).Return(mockClient)
@@ -204,11 +204,11 @@ func TestGetProjectList_IgnoresProject(t *testing.T) {
 	// The ignored list contains the project path, so it should be filtered out
 	projects, warn := svc.(*sheriffService).getProjectList(
 		[]config.ProjectLocation{{Type: repository.Gitlab, Path: "group/to/scan"}},
-		[]config.ProjectLocation{{Type: repository.Gitlab, Path: "group/to/scan"}},
+		[]config.ProjectLocation{{Type: repository.Gitlab, Path: "path/of/project"}},
 	)
 	assert.Nil(t, warn)
 	assert.Empty(t, projects)
-	mockClient.AssertNotCalled(t, "GetProjectList", []string{"group/to/scan"})
+	mockClient.AssertNotCalled(t, "GetProjectList", []string{"path/of/project"})
 }
 
 type mockRepoService struct {


### PR DESCRIPTION
We should be ignoring the listed projects that are fetched from gitlab/github, since this list is the one containing the sub-projects & sub-groups